### PR TITLE
Add optional autostart on entering The Twilight Strand

### DIFF
--- a/POELiveSplitComponent/Component/Settings/ComponentSettings.cs
+++ b/POELiveSplitComponent/Component/Settings/ComponentSettings.cs
@@ -16,6 +16,7 @@ namespace POELiveSplitComponent.Component.Settings
         private const string LOG_KEY = "log.location";
         private const string LOAD_REMOVAL_FLAG = "load.removal";
         private const string AUTO_SPLIT_FLAG = "auto.split";
+        private const string AUTO_START_TWILIGHT_STRAND = "auto.start.twilight.strand";
         private const string SPLIT_ZONES = "split.zones.on";
         private const string SPLIT_ZONE = "split.zone";
         private const string SPLIT_LABYRINTH_TYPE = "split.labyrinth.type";
@@ -46,6 +47,8 @@ namespace POELiveSplitComponent.Component.Settings
 
         public bool AutoSplitEnabled;
 
+        public bool AutoStartOnTwilightStrand;
+
         public HashSet<IZone> SplitZones { get; private set; }
 
         public HashSet<int> SplitZoneLevels { get; private set; }
@@ -68,6 +71,7 @@ namespace POELiveSplitComponent.Component.Settings
         private void setDefaults()
         {
             AutoSplitEnabled = true;
+            AutoStartOnTwilightStrand = false;
             LoadRemovalEnabled = false;
             LabSplitType = LabSplitMode.AllZones;
             GenerateWithIcons = true;
@@ -85,6 +89,7 @@ namespace POELiveSplitComponent.Component.Settings
             SettingsHelper.CreateSetting(document, settingsNode, LOG_KEY, LogLocation);
             SettingsHelper.CreateSetting(document, settingsNode, LOAD_REMOVAL_FLAG, LoadRemovalEnabled);
             SettingsHelper.CreateSetting(document, settingsNode, AUTO_SPLIT_FLAG, AutoSplitEnabled);
+            SettingsHelper.CreateSetting(document, settingsNode, AUTO_START_TWILIGHT_STRAND, AutoStartOnTwilightStrand);
             SettingsHelper.CreateSetting(document, settingsNode, SPLIT_LABYRINTH_TYPE, LabSplitType);
             SettingsHelper.CreateSetting(document, settingsNode, SPLIT_CRITERIA, CriteriaToSplit);
             SettingsHelper.CreateSetting(document, settingsNode, GENERATE_WITH_ICONS, GenerateWithIcons);
@@ -115,6 +120,10 @@ namespace POELiveSplitComponent.Component.Settings
                     if (element[AUTO_SPLIT_FLAG] != null)
                     {
                         AutoSplitEnabled = bool.Parse(element[AUTO_SPLIT_FLAG].InnerText);
+                    }
+                    if (element[AUTO_START_TWILIGHT_STRAND] != null)
+                    {
+                        AutoStartOnTwilightStrand = bool.Parse(element[AUTO_START_TWILIGHT_STRAND].InnerText);
                     }
                     if (element[SPLIT_LABYRINTH_TYPE] != null)
                     {

--- a/POELiveSplitComponent/Component/SettingsControl.Designer.cs
+++ b/POELiveSplitComponent/Component/SettingsControl.Designer.cs
@@ -36,6 +36,7 @@
             this.radioAllLab = new System.Windows.Forms.RadioButton();
             this.radioLab = new System.Windows.Forms.RadioButton();
             this.checkAutoSplit = new System.Windows.Forms.CheckBox();
+            this.checkAutoStartTwilightStrand = new System.Windows.Forms.CheckBox();
             this.radioLevels = new System.Windows.Forms.RadioButton();
             this.radioZones = new System.Windows.Forms.RadioButton();
             this.labelSplitOn = new System.Windows.Forms.Label();
@@ -64,6 +65,7 @@
             this.groupBox1.Controls.Add(this.groupBoxLab);
             this.groupBox1.Controls.Add(this.radioLab);
             this.groupBox1.Controls.Add(this.checkAutoSplit);
+            this.groupBox1.Controls.Add(this.checkAutoStartTwilightStrand);
             this.groupBox1.Controls.Add(this.radioLevels);
             this.groupBox1.Controls.Add(this.radioZones);
             this.groupBox1.Controls.Add(this.labelSplitOn);
@@ -146,6 +148,18 @@
             this.checkAutoSplit.UseVisualStyleBackColor = true;
             this.checkAutoSplit.CheckedChanged += new System.EventHandler(this.HandleAutoSplitChanged);
             // 
+            // checkAutoStartTwilightStrand
+            //
+            this.checkAutoStartTwilightStrand.AutoSize = true;
+            this.checkAutoStartTwilightStrand.Location = new System.Drawing.Point(152, 20);
+            this.checkAutoStartTwilightStrand.Name = "checkAutoStartTwilightStrand";
+            this.checkAutoStartTwilightStrand.Size = new System.Drawing.Size(171, 17);
+            this.checkAutoStartTwilightStrand.TabIndex = 17;
+            this.checkAutoStartTwilightStrand.Text = "Auto-start at Twilight Strand";
+            this.toolTip.SetToolTip(this.checkAutoStartTwilightStrand, "Starts the timer when the player enters The Twilight Strand.");
+            this.checkAutoStartTwilightStrand.UseVisualStyleBackColor = true;
+            this.checkAutoStartTwilightStrand.CheckedChanged += new System.EventHandler(this.HandleAutoStartTwilightStrandChanged);
+            //
             // radioLevels
             // 
             this.radioLevels.AutoSize = true;
@@ -368,6 +382,7 @@
         private System.Windows.Forms.RadioButton radioLab;
         private System.Windows.Forms.GroupBox groupBoxLab;
         private System.Windows.Forms.Panel panelSplitList;
+        private System.Windows.Forms.CheckBox checkAutoStartTwilightStrand;
     }
 }
 

--- a/POELiveSplitComponent/Component/SettingsControl.cs
+++ b/POELiveSplitComponent/Component/SettingsControl.cs
@@ -27,6 +27,8 @@ namespace POELiveSplitComponent.Component
         public void XmlRefresh()
         {
             checkAutoSplit.Checked = settings.AutoSplitEnabled;
+            checkAutoStartTwilightStrand.Checked = settings.AutoStartOnTwilightStrand;
+            checkAutoStartTwilightStrand.Enabled = settings.AutoSplitEnabled;
             checkLoadRemoval.Checked = settings.LoadRemovalEnabled;
             textLogLocation.Text = settings.LogLocation;
             radioZones.Checked = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones;
@@ -71,6 +73,12 @@ namespace POELiveSplitComponent.Component
         private void HandleAutoSplitChanged(object sender, EventArgs e)
         {
             settings.AutoSplitEnabled = checkAutoSplit.Checked;
+            checkAutoStartTwilightStrand.Enabled = checkAutoSplit.Checked;
+        }
+
+        private void HandleAutoStartTwilightStrandChanged(object sender, EventArgs e)
+        {
+            settings.AutoStartOnTwilightStrand = checkAutoStartTwilightStrand.Checked;
         }
 
         private void handleLoadRemovalChanged(object sender, EventArgs e)

--- a/POELiveSplitComponent/Component/Timer/LoadRemoverSplitter.cs
+++ b/POELiveSplitComponent/Component/Timer/LoadRemoverSplitter.cs
@@ -12,6 +12,7 @@ namespace POELiveSplitComponent.Component.Timer
         // Zone that lab runners must enter before the lab. Unique zone name.
         private static IZone LAB_ENTRANCE = Zone.Parse("Aspirants' Plaza", new HashSet<IZone>());
         private static IZone ASPIRANTS_TRIAL = Zone.Parse("Aspirant's Trial", new HashSet<IZone>());
+        private const string TWILIGHT_STRAND = "The Twilight Strand";
         private ComponentSettings settings;
         private ITimerModel timer;
         private long loadTimes = 0;
@@ -56,8 +57,9 @@ namespace POELiveSplitComponent.Component.Timer
             }
                         
             IZone zone = Zone.Parse(zoneName, encounteredZones);
+            bool autoStarted = AutoStartOnTwilightStrand(zoneName);
 
-            if (settings.AutoSplitEnabled)
+            if (settings.AutoSplitEnabled && !autoStarted)
             {
                 if (settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Labyrinth)
                 {
@@ -83,6 +85,17 @@ namespace POELiveSplitComponent.Component.Timer
                 }
             }
             previousZone = zone;
+        }
+
+        private bool AutoStartOnTwilightStrand(string zoneName)
+        {
+            if (!settings.AutoSplitEnabled || !settings.AutoStartOnTwilightStrand ||
+                zoneName != TWILIGHT_STRAND || timer.CurrentState.CurrentPhase != TimerPhase.NotRunning)
+            {
+                return false;
+            }
+            timer.Start();
+            return true;
         }
 
         public void HandleResetRuns()

--- a/POELiveSplitComponentTests/Component/Settings/ComponentSettingsTests.cs
+++ b/POELiveSplitComponentTests/Component/Settings/ComponentSettingsTests.cs
@@ -18,6 +18,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             ComponentSettings settings = new ComponentSettings();
             settings.SetSettings(nodeSettings);
             Assert.IsTrue(settings.AutoSplitEnabled);
+            Assert.IsFalse(settings.AutoStartOnTwilightStrand);
             Assert.IsFalse(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.AllZones, settings.LabSplitType);
             Assert.IsTrue(settings.GenerateWithIcons);
@@ -46,6 +47,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             ComponentSettings settings = new ComponentSettings();
             settings.SetSettings(nodeSettings);
             Assert.IsTrue(settings.AutoSplitEnabled);
+            Assert.IsFalse(settings.AutoStartOnTwilightStrand);
             Assert.IsTrue(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.AllZones, settings.LabSplitType);
             Assert.IsTrue(settings.GenerateWithIcons);
@@ -81,6 +83,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             ComponentSettings settings = new ComponentSettings();
             settings.SetSettings(nodeSettings);
             Assert.IsTrue(settings.AutoSplitEnabled);
+            Assert.IsFalse(settings.AutoStartOnTwilightStrand);
             Assert.IsFalse(settings.LoadRemovalEnabled);
             Assert.IsTrue(settings.GenerateWithIcons);
             Assert.AreEqual(ComponentSettings.SplitCriteria.Levels, settings.CriteriaToSplit);
@@ -114,6 +117,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             ComponentSettings settings = new ComponentSettings();
             settings.SetSettings(nodeSettings);
             Assert.IsTrue(settings.AutoSplitEnabled);
+            Assert.IsFalse(settings.AutoStartOnTwilightStrand);
             Assert.IsFalse(settings.LoadRemovalEnabled);
             Assert.IsTrue(settings.GenerateWithIcons);
             Assert.AreEqual(ComponentSettings.SplitCriteria.Labyrinth, settings.CriteriaToSplit);
@@ -133,6 +137,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             settings = new ComponentSettings();
             settings.SetSettings(node);
             Assert.IsTrue(settings.AutoSplitEnabled);
+            Assert.IsFalse(settings.AutoStartOnTwilightStrand);
             Assert.IsFalse(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.AllZones, settings.LabSplitType);
             Assert.IsTrue(settings.GenerateWithIcons);
@@ -148,6 +153,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             XmlDocument xml = new XmlDocument();
             ComponentSettings settings = new ComponentSettings();
             settings.AutoSplitEnabled = false;
+            settings.AutoStartOnTwilightStrand = true;
             settings.LoadRemovalEnabled = true;
             settings.LabSplitType = ComponentSettings.LabSplitMode.Trials;
             settings.GenerateWithIcons = false;
@@ -160,6 +166,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             settings = new ComponentSettings();
             settings.SetSettings(node);
             Assert.IsFalse(settings.AutoSplitEnabled);
+            Assert.IsTrue(settings.AutoStartOnTwilightStrand);
             Assert.IsTrue(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.Trials, settings.LabSplitType);
             Assert.IsFalse(settings.GenerateWithIcons);
@@ -174,6 +181,7 @@ namespace POELiveSplitComponentTests.Component.Settings
         {
             ComponentSettings settings = new ComponentSettings();
             settings.AutoSplitEnabled = false;
+            settings.AutoStartOnTwilightStrand = true;
             settings.LoadRemovalEnabled = true;
             settings.LabSplitType = ComponentSettings.LabSplitMode.Trials;
             settings.GenerateWithIcons = false;
@@ -186,6 +194,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             XmlDocument xml = new XmlDocument();
             settings.SetSettings(new ComponentSettings().GetSettings(xml));
             Assert.IsTrue(settings.AutoSplitEnabled);
+            Assert.IsFalse(settings.AutoStartOnTwilightStrand);
             Assert.IsFalse(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.AllZones, settings.LabSplitType);
             Assert.IsTrue(settings.GenerateWithIcons);
@@ -200,6 +209,7 @@ namespace POELiveSplitComponentTests.Component.Settings
         {
             ComponentSettings settings = new ComponentSettings();
             settings.AutoSplitEnabled = false;
+            settings.AutoStartOnTwilightStrand = true;
             settings.LoadRemovalEnabled = true;
             settings.LabSplitType = ComponentSettings.LabSplitMode.Trials;
             settings.GenerateWithIcons = false;
@@ -215,6 +225,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             XmlNode nodeSettings = xml.FirstChild;
             settings.SetSettings(nodeSettings);
             Assert.IsTrue(settings.AutoSplitEnabled);
+            Assert.IsFalse(settings.AutoStartOnTwilightStrand);
             Assert.IsTrue(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.AllZones, settings.LabSplitType);
             Assert.IsTrue(settings.GenerateWithIcons);

--- a/POELiveSplitComponentTests/Component/Timer/LoadRemoverSplitterTests.cs
+++ b/POELiveSplitComponentTests/Component/Timer/LoadRemoverSplitterTests.cs
@@ -15,6 +15,7 @@ namespace POELiveSplitComponentTests.Component.Timer
         {
             public int NumSplits = 0;
             public int NumStarts = 0;
+            private LiveSplitState currentState = (LiveSplitState)FormatterServices.GetUninitializedObject(typeof(LiveSplitState));
 
             public void Split()
             {
@@ -24,18 +25,19 @@ namespace POELiveSplitComponentTests.Component.Timer
             public void Start()
             {
                 NumStarts++;
+                currentState.CurrentPhase = TimerPhase.Running;
             }
 
             public LiveSplitState CurrentState
             {
                 get
                 {
-                    return (LiveSplitState)FormatterServices.GetUninitializedObject(typeof(LiveSplitState));
+                    return currentState;
                 }
 
                 set
                 {
-                    throw new NotImplementedException();
+                    currentState = value;
                 }
             }
 
@@ -66,6 +68,7 @@ namespace POELiveSplitComponentTests.Component.Timer
             {
                 NumSplits = 0;
                 NumStarts = 0;
+                currentState.CurrentPhase = TimerPhase.NotRunning;
             }
 
             public void Reset(bool updateSplits)
@@ -221,6 +224,7 @@ namespace POELiveSplitComponentTests.Component.Timer
                 settings.SplitZones.Add(LIONEYES1);
                 settings.SplitZoneLevels.Add(70);
                 settings.SplitLevels.Add(10);
+                settings.AutoStartOnTwilightStrand = true;
                 settings.AutoSplitEnabled = false;
                 MockTimerModel timer = new MockTimerModel();
 
@@ -230,8 +234,27 @@ namespace POELiveSplitComponentTests.Component.Timer
                 splitter.HandleLevelUp(2, 70);
                 splitter.HandleLoadStart(3);
                 splitter.HandleLoadEnd(4, "Lioneye's Watch");
+                splitter.HandleLoadEnd(5, "The Twilight Strand");
                 Assert.AreEqual(0, timer.NumSplits);
+                Assert.AreEqual(0, timer.NumStarts);
             }
+        }
+
+        [TestMethod()]
+        public void HandleAutoStartTwilightStrandTest()
+        {
+            ComponentSettings settings = new ComponentSettings();
+            settings.AutoStartOnTwilightStrand = true;
+            MockTimerModel timer = new MockTimerModel();
+
+            LoadRemoverSplitter splitter = new LoadRemoverSplitter(timer, settings);
+            splitter.HandleLoadEnd(1, "The Coast");
+            Assert.AreEqual(0, timer.NumStarts);
+            splitter.HandleLoadEnd(2, "The Twilight Strand");
+            Assert.AreEqual(1, timer.NumStarts);
+            Assert.AreEqual(0, timer.NumSplits);
+            splitter.HandleLoadEnd(3, "The Twilight Strand");
+            Assert.AreEqual(1, timer.NumStarts);
         }
 
         [TestMethod()]


### PR DESCRIPTION
## Summary
Added an optional autostart when entering The Twilight Strand to streamline timer startup at the beginning of a new run.

Because not everyone may want this behavior enabled, this PR adds a checkbox setting to disable the feature.

<img width="349" height="58" alt="image" src="https://github.com/user-attachments/assets/8f7e1fe5-c460-40d8-8cc3-bc3c4bc0721d" />

## Notes
This PR has merge conflicts with https://github.com/brandondong/POE-LiveSplit-Component/pull/24
- POELiveSplitComponent/Component/SettingsControl.Designer.cs
- POELiveSplitComponent/Component/Timer/LoadRemoverSplitter.cs
- POELiveSplitComponentTests/Component/Timer/LoadRemoverSplitterTests.cs

Happy to help with merging if either one gets merged into master.

## Testing
- [x] Test cases passed
- [x] Manually did a few runs to verify autostarts triggers correctly