### PR TITLE
Add combinable passive skill point split mode

### DIFF
--- a/POELiveSplitComponent/Component/GameClient/ClientParser.cs
+++ b/POELiveSplitComponent/Component/GameClient/ClientParser.cs
@@ -15,6 +15,8 @@ namespace POELiveSplitComponent.Component.GameClient
 
         private static readonly Regex IZARO_DIALOGUE = new Regex(TIMESTAMP_SECTION + @".*Izaro: (.*)");
 
+        private static readonly Regex CLIENT_MESSAGE = new Regex(TIMESTAMP_SECTION + @".*\[INFO Client \d+\] : (.*)$");
+
         private IClientEventHandler splitter;
 
         public ClientParser(IClientEventHandler splitter)
@@ -43,13 +45,20 @@ namespace POELiveSplitComponent.Component.GameClient
             {
                 GroupCollection groups = match.Groups;
                 splitter.HandleLevelUp(long.Parse(groups[1].Value), int.Parse(groups[2].Value));
+                return;
             }
             match = IZARO_DIALOGUE.Match(s);
             if (match.Success)
             {
                 GroupCollection groups = match.Groups;
                 splitter.HandleIzaroDialogue(long.Parse(groups[1].Value), groups[2].Value);
-
+                return;
+            }
+            match = CLIENT_MESSAGE.Match(s);
+            if (match.Success)
+            {
+                GroupCollection groups = match.Groups;
+                splitter.HandleClientMessage(long.Parse(groups[1].Value), groups[2].Value);
             }
         }
     }

--- a/POELiveSplitComponent/Component/GameClient/IClientEventHandler.cs
+++ b/POELiveSplitComponent/Component/GameClient/IClientEventHandler.cs
@@ -6,5 +6,6 @@
         void HandleLoadEnd(long timestamp, string zoneName);
         void HandleLevelUp(long timestamp, int level);
         void HandleIzaroDialogue(long timestamp, string dialogue);
+        void HandleClientMessage(long timestamp, string message);
     }
 }

--- a/POELiveSplitComponent/Component/Settings/ComponentSettings.cs
+++ b/POELiveSplitComponent/Component/Settings/ComponentSettings.cs
@@ -9,7 +9,7 @@ namespace POELiveSplitComponent.Component.Settings
 {
     public class ComponentSettings
     {
-        public enum SplitCriteria { Zones, Levels, Labyrinth };
+        public enum SplitCriteria { Zones, Levels, Labyrinth, PassiveSkillPoints };
 
         public enum LabSplitMode { AllZones, Trials };
 
@@ -22,6 +22,8 @@ namespace POELiveSplitComponent.Component.Settings
         private const string SPLIT_CRITERIA = "split.criteria";
         private const string SPLIT_LEVELS = "split.levels.on";
         private const string SPLIT_LEVEL = "split.level";
+        private const string SPLIT_PASSIVE_SKILL_POINTS = "split.passive.skill.points.on";
+        private const string SPLIT_PASSIVE_SKILL_POINT = "split.passive.skill.point";
         private const string GENERATE_WITH_ICONS = "generate.with.icons";
         private const string LEGACY_SPLIT_LABYRINTH = "split.labyrinth";
 
@@ -56,6 +58,8 @@ namespace POELiveSplitComponent.Component.Settings
 
         public HashSet<int> SplitLevels { get; private set; }
 
+        public HashSet<PassiveSkillPointSplit> PassiveSkillPointSplits { get; private set; }
+
         public bool GenerateWithIcons;
 
         public Action HandleLogLocationChanged { get; set; }
@@ -76,6 +80,7 @@ namespace POELiveSplitComponent.Component.Settings
             SplitZones = new HashSet<IZone>();
             SplitZoneLevels = new HashSet<int>();
             SplitLevels = new HashSet<int>();
+            PassiveSkillPointSplits = new HashSet<PassiveSkillPointSplit>();
         }
 
         public XmlNode GetSettings(XmlDocument document)
@@ -91,6 +96,7 @@ namespace POELiveSplitComponent.Component.Settings
 
             settingsNode.AppendChild(SerializeZones(document));
             settingsNode.AppendChild(SerializeLevels(document));
+            settingsNode.AppendChild(SerializePassiveSkillPointSplits(document));
 
             return settingsNode;
         }
@@ -151,6 +157,17 @@ namespace POELiveSplitComponent.Component.Settings
                             SplitLevels.Add(Int32.Parse(child.InnerText));
                         }
                     }
+                    if (element[SPLIT_PASSIVE_SKILL_POINTS] != null)
+                    {
+                        HashSet<string> deserialized = DeserializePassiveSkillPointSplits(element[SPLIT_PASSIVE_SKILL_POINTS]);
+                        foreach (PassiveSkillPointSplit split in PassiveSkillPointSplit.PRESETS)
+                        {
+                            if (deserialized.Contains(split.Serialize()))
+                            {
+                                PassiveSkillPointSplits.Add(split);
+                            }
+                        }
+                    }
                     if (element[LEGACY_SPLIT_LABYRINTH] != null && bool.Parse(element[LEGACY_SPLIT_LABYRINTH].InnerText))
                     {
                         // Override to support old split settings.
@@ -189,6 +206,16 @@ namespace POELiveSplitComponent.Component.Settings
             return parent;
         }
 
+        private XmlElement SerializePassiveSkillPointSplits(XmlDocument document)
+        {
+            XmlElement parent = SettingsHelper.ToElement(document, SPLIT_PASSIVE_SKILL_POINTS, (string)null);
+            foreach (PassiveSkillPointSplit split in PassiveSkillPointSplits)
+            {
+                SettingsHelper.CreateSetting(document, parent, SPLIT_PASSIVE_SKILL_POINT, split.Serialize());
+            }
+            return parent;
+        }
+
         private HashSet<string> DeserializeZones(XmlElement element)
         {
             HashSet<string> zones = new HashSet<string>();
@@ -197,6 +224,16 @@ namespace POELiveSplitComponent.Component.Settings
                 zones.Add(child.InnerText);
             }
             return zones;
+        }
+
+        private HashSet<string> DeserializePassiveSkillPointSplits(XmlElement element)
+        {
+            HashSet<string> splits = new HashSet<string>();
+            foreach (XmlNode child in element.GetElementsByTagName(SPLIT_PASSIVE_SKILL_POINT))
+            {
+                splits.Add(child.InnerText);
+            }
+            return splits;
         }
     }
 }

--- a/POELiveSplitComponent/Component/Settings/ComponentSettings.cs
+++ b/POELiveSplitComponent/Component/Settings/ComponentSettings.cs
@@ -25,6 +25,7 @@ namespace POELiveSplitComponent.Component.Settings
         private const string SPLIT_PASSIVE_SKILL_POINTS = "split.passive.skill.points.on";
         private const string SPLIT_PASSIVE_SKILL_POINT = "split.passive.skill.point";
         private const string GENERATE_WITH_ICONS = "generate.with.icons";
+        private const string COMBINE_CAMPAIGN_AND_PASSIVE_SKILL_POINT_SPLITS = "combine.campaign.and.passive.skill.point.splits";
         private const string LEGACY_SPLIT_LABYRINTH = "split.labyrinth";
 
         private const string DEFAULT_LOG_LOCATION = @"C:\Program Files (x86)\Grinding Gear Games\Path of Exile\logs\Client.txt";
@@ -62,6 +63,8 @@ namespace POELiveSplitComponent.Component.Settings
 
         public bool GenerateWithIcons;
 
+        public bool CombineCampaignAndPassiveSkillPointSplits;
+
         public Action HandleLogLocationChanged { get; set; }
 
         public ComponentSettings()
@@ -75,6 +78,7 @@ namespace POELiveSplitComponent.Component.Settings
             LoadRemovalEnabled = false;
             LabSplitType = LabSplitMode.AllZones;
             GenerateWithIcons = true;
+            CombineCampaignAndPassiveSkillPointSplits = false;
             CriteriaToSplit = SplitCriteria.Zones;
             logLocation = DEFAULT_LOG_LOCATION;
             SplitZones = new HashSet<IZone>();
@@ -93,6 +97,8 @@ namespace POELiveSplitComponent.Component.Settings
             SettingsHelper.CreateSetting(document, settingsNode, SPLIT_LABYRINTH_TYPE, LabSplitType);
             SettingsHelper.CreateSetting(document, settingsNode, SPLIT_CRITERIA, CriteriaToSplit);
             SettingsHelper.CreateSetting(document, settingsNode, GENERATE_WITH_ICONS, GenerateWithIcons);
+            SettingsHelper.CreateSetting(document, settingsNode, COMBINE_CAMPAIGN_AND_PASSIVE_SKILL_POINT_SPLITS,
+                CombineCampaignAndPassiveSkillPointSplits);
 
             settingsNode.AppendChild(SerializeZones(document));
             settingsNode.AppendChild(SerializeLevels(document));
@@ -133,6 +139,11 @@ namespace POELiveSplitComponent.Component.Settings
                     if (element[GENERATE_WITH_ICONS] != null)
                     {
                         GenerateWithIcons = bool.Parse(element[GENERATE_WITH_ICONS].InnerText);
+                    }
+                    if (element[COMBINE_CAMPAIGN_AND_PASSIVE_SKILL_POINT_SPLITS] != null)
+                    {
+                        CombineCampaignAndPassiveSkillPointSplits =
+                            bool.Parse(element[COMBINE_CAMPAIGN_AND_PASSIVE_SKILL_POINT_SPLITS].InnerText);
                     }
                     if (element[SPLIT_ZONES] != null)
                     {

--- a/POELiveSplitComponent/Component/SettingsControl.Designer.cs
+++ b/POELiveSplitComponent/Component/SettingsControl.Designer.cs
@@ -35,6 +35,7 @@
             this.labelLabDescription = new System.Windows.Forms.Label();
             this.radioAllLab = new System.Windows.Forms.RadioButton();
             this.radioLab = new System.Windows.Forms.RadioButton();
+            this.radioPassiveSkillPoints = new System.Windows.Forms.RadioButton();
             this.checkAutoSplit = new System.Windows.Forms.CheckBox();
             this.radioLevels = new System.Windows.Forms.RadioButton();
             this.radioZones = new System.Windows.Forms.RadioButton();
@@ -62,6 +63,7 @@
             // groupBox1
             // 
             this.groupBox1.Controls.Add(this.groupBoxLab);
+            this.groupBox1.Controls.Add(this.radioPassiveSkillPoints);
             this.groupBox1.Controls.Add(this.radioLab);
             this.groupBox1.Controls.Add(this.checkAutoSplit);
             this.groupBox1.Controls.Add(this.radioLevels);
@@ -133,6 +135,19 @@
             this.radioLab.UseVisualStyleBackColor = true;
             this.radioLab.CheckedChanged += new System.EventHandler(this.HandleSplitCriteriaChanged);
             // 
+            // radioPassiveSkillPoints
+            //
+            this.radioPassiveSkillPoints.AutoSize = true;
+            this.radioPassiveSkillPoints.Location = new System.Drawing.Point(226, 65);
+            this.radioPassiveSkillPoints.Name = "radioPassiveSkillPoints";
+            this.radioPassiveSkillPoints.Size = new System.Drawing.Size(77, 17);
+            this.radioPassiveSkillPoints.TabIndex = 17;
+            this.radioPassiveSkillPoints.TabStop = true;
+            this.radioPassiveSkillPoints.Text = "Passive Skill Pts";
+            this.toolTip.SetToolTip(this.radioPassiveSkillPoints, "Performs a split when the current passive skill point quest segment receives a passive point reward.");
+            this.radioPassiveSkillPoints.UseVisualStyleBackColor = true;
+            this.radioPassiveSkillPoints.CheckedChanged += new System.EventHandler(this.HandleSplitCriteriaChanged);
+            //
             // checkAutoSplit
             // 
             this.checkAutoSplit.AutoSize = true;
@@ -368,6 +383,7 @@
         private System.Windows.Forms.RadioButton radioLab;
         private System.Windows.Forms.GroupBox groupBoxLab;
         private System.Windows.Forms.Panel panelSplitList;
+        private System.Windows.Forms.RadioButton radioPassiveSkillPoints;
     }
 }
 

--- a/POELiveSplitComponent/Component/SettingsControl.Designer.cs
+++ b/POELiveSplitComponent/Component/SettingsControl.Designer.cs
@@ -44,6 +44,7 @@
             this.checkedSplitList = new System.Windows.Forms.CheckedListBox();
             this.checkSelectAll = new System.Windows.Forms.CheckBox();
             this.checkIcons = new System.Windows.Forms.CheckBox();
+            this.checkCombineCampaignPassiveSkillPoints = new System.Windows.Forms.CheckBox();
             this.createSplitsButton = new System.Windows.Forms.Button();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.linkLoadSetup = new System.Windows.Forms.LinkLabel();
@@ -59,9 +60,9 @@
             this.panelSplitList.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // groupBox1
-            // 
+            //
             this.groupBox1.Controls.Add(this.groupBoxLab);
             this.groupBox1.Controls.Add(this.radioPassiveSkillPoints);
             this.groupBox1.Controls.Add(this.radioLab);
@@ -76,9 +77,9 @@
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Auto Split";
-            // 
+            //
             // groupBoxLab
-            // 
+            //
             this.groupBoxLab.Controls.Add(this.radioAspirant);
             this.groupBoxLab.Controls.Add(this.labelLabDescription);
             this.groupBoxLab.Controls.Add(this.radioAllLab);
@@ -201,6 +202,7 @@
             this.panelSplitList.Controls.Add(this.checkedSplitList);
             this.panelSplitList.Controls.Add(this.checkSelectAll);
             this.panelSplitList.Controls.Add(this.checkIcons);
+            this.panelSplitList.Controls.Add(this.checkCombineCampaignPassiveSkillPoints);
             this.panelSplitList.Controls.Add(this.createSplitsButton);
             this.panelSplitList.Location = new System.Drawing.Point(12, 88);
             this.panelSplitList.Name = "panelSplitList";
@@ -240,7 +242,19 @@
             this.checkIcons.Text = "With Icons";
             this.checkIcons.UseVisualStyleBackColor = true;
             this.checkIcons.CheckedChanged += new System.EventHandler(this.HandleIconsChecked);
-            // 
+            //
+            // checkCombineCampaignPassiveSkillPoints
+            //
+            this.checkCombineCampaignPassiveSkillPoints.AutoSize = true;
+            this.checkCombineCampaignPassiveSkillPoints.Location = new System.Drawing.Point(196, 228);
+            this.checkCombineCampaignPassiveSkillPoints.Name = "checkCombineCampaignPassiveSkillPoints";
+            this.checkCombineCampaignPassiveSkillPoints.Size = new System.Drawing.Size(171, 17);
+            this.checkCombineCampaignPassiveSkillPoints.TabIndex = 18;
+            this.checkCombineCampaignPassiveSkillPoints.Text = "Combine Campaign + Skill Pts";
+            this.toolTip.SetToolTip(this.checkCombineCampaignPassiveSkillPoints, "Generate and split against selected Campaign and Passive Skill Pts entries together.");
+            this.checkCombineCampaignPassiveSkillPoints.UseVisualStyleBackColor = true;
+            this.checkCombineCampaignPassiveSkillPoints.CheckedChanged += new System.EventHandler(this.HandleCombineCampaignPassiveSkillPointsChecked);
+            //
             // createSplitsButton
             // 
             this.createSplitsButton.Location = new System.Drawing.Point(0, 223);
@@ -377,6 +391,7 @@
         private System.Windows.Forms.ToolTip toolTip;
         private System.Windows.Forms.CheckBox checkAutoSplit;
         private System.Windows.Forms.CheckBox checkIcons;
+        private System.Windows.Forms.CheckBox checkCombineCampaignPassiveSkillPoints;
         private System.Windows.Forms.Label labelLabDescription;
         private System.Windows.Forms.RadioButton radioAllLab;
         private System.Windows.Forms.RadioButton radioAspirant;
@@ -386,4 +401,3 @@
         private System.Windows.Forms.RadioButton radioPassiveSkillPoints;
     }
 }
-

--- a/POELiveSplitComponent/Component/SettingsControl.cs
+++ b/POELiveSplitComponent/Component/SettingsControl.cs
@@ -32,6 +32,7 @@ namespace POELiveSplitComponent.Component
             radioZones.Checked = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones;
             radioLevels.Checked = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Levels;
             radioLab.Checked = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Labyrinth;
+            radioPassiveSkillPoints.Checked = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.PassiveSkillPoints;
             checkIcons.Checked = settings.GenerateWithIcons;
             radioAllLab.Checked = settings.LabSplitType == ComponentSettings.LabSplitMode.AllZones;
             radioAspirant.Checked = settings.LabSplitType == ComponentSettings.LabSplitMode.Trials;
@@ -44,7 +45,8 @@ namespace POELiveSplitComponent.Component
             groupBoxLab.Visible = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Labyrinth;
 
             panelSplitList.Visible = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones || 
-                settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Levels;
+                settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Levels ||
+                settings.CriteriaToSplit == ComponentSettings.SplitCriteria.PassiveSkillPoints;
             checkIcons.Visible = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones;
 
             checkedSplitList.Items.Clear();
@@ -64,6 +66,13 @@ namespace POELiveSplitComponent.Component
                 for (int i = 2; i <= 100; i++)
                 {
                     checkedSplitList.Items.Add(new LevelLabel(i), settings.SplitLevels.Contains(i));
+                }
+            }
+            else if (settings.CriteriaToSplit == ComponentSettings.SplitCriteria.PassiveSkillPoints)
+            {
+                foreach (PassiveSkillPointSplit split in PassiveSkillPointSplit.PRESETS)
+                {
+                    checkedSplitList.Items.Add(split, settings.PassiveSkillPointSplits.Contains(split));
                 }
             }
         }
@@ -153,6 +162,18 @@ namespace POELiveSplitComponent.Component
                     settings.SplitLevels.Remove(level.Level);
                 }
             }
+            else if (settings.CriteriaToSplit == ComponentSettings.SplitCriteria.PassiveSkillPoints)
+            {
+                PassiveSkillPointSplit split = (PassiveSkillPointSplit)selectedItem;
+                if (e.NewValue == CheckState.Checked)
+                {
+                    settings.PassiveSkillPointSplits.Add(split);
+                }
+                else
+                {
+                    settings.PassiveSkillPointSplits.Remove(split);
+                }
+            }
         }
 
         private void HandleSelectAll(object sender, EventArgs e)
@@ -236,6 +257,10 @@ namespace POELiveSplitComponent.Component
             else if (radioLab.Checked)
             {
                 settings.CriteriaToSplit = ComponentSettings.SplitCriteria.Labyrinth;
+            }
+            else if (radioPassiveSkillPoints.Checked)
+            {
+                settings.CriteriaToSplit = ComponentSettings.SplitCriteria.PassiveSkillPoints;
             }
             updateSplitCriteriaSpecificArea();
         }

--- a/POELiveSplitComponent/Component/SettingsControl.cs
+++ b/POELiveSplitComponent/Component/SettingsControl.cs
@@ -34,6 +34,7 @@ namespace POELiveSplitComponent.Component
             radioLab.Checked = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Labyrinth;
             radioPassiveSkillPoints.Checked = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.PassiveSkillPoints;
             checkIcons.Checked = settings.GenerateWithIcons;
+            checkCombineCampaignPassiveSkillPoints.Checked = settings.CombineCampaignAndPassiveSkillPointSplits;
             radioAllLab.Checked = settings.LabSplitType == ComponentSettings.LabSplitMode.AllZones;
             radioAspirant.Checked = settings.LabSplitType == ComponentSettings.LabSplitMode.Trials;
 
@@ -48,6 +49,8 @@ namespace POELiveSplitComponent.Component
                 settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Levels ||
                 settings.CriteriaToSplit == ComponentSettings.SplitCriteria.PassiveSkillPoints;
             checkIcons.Visible = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones;
+            checkCombineCampaignPassiveSkillPoints.Visible = settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones ||
+                settings.CriteriaToSplit == ComponentSettings.SplitCriteria.PassiveSkillPoints;
 
             checkedSplitList.Items.Clear();
             if (settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones)
@@ -198,26 +201,14 @@ namespace POELiveSplitComponent.Component
                 return;
             }
             state.Run.Clear();
-            for (int i = 0; i < checkedSplitList.Items.Count; i++)
+            if (GeneratesCampaignRoute())
             {
-                if (checkedSplitList.GetItemChecked(i))
-                {
-                    object selectedItem = checkedSplitList.Items[i];
-                    if (selectedItem is IZone)
-                    {
-                        IZone zone = (IZone)selectedItem;
-                        Image icon = null;
-                        if (settings.GenerateWithIcons)
-                        {
-                            icon = iconForType(Zone.ICONTYPES[zone]);
-                        }
-                        state.Run.AddSegment(zone.SplitName(), default(Time), default(Time), icon);
-                    }
-                    else
-                    {
-                        state.Run.AddSegment(selectedItem.ToString());
-                    }
-                }
+                AddCampaignSplits();
+                AddPassiveSkillPointSplits();
+            }
+            else
+            {
+                AddCheckedSplits();
             }
             if (state.Run.Count == 0)
             {
@@ -229,6 +220,58 @@ namespace POELiveSplitComponent.Component
                 "The splits can be edited in the Splits Editor after saving and reopening.\n" + 
                 "If the split names do not match the order of your zone progression, they can be reordered using that editor.",
                 "Generate Splits", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        private bool GeneratesCampaignRoute()
+        {
+            return settings.CombineCampaignAndPassiveSkillPointSplits &&
+                (settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones ||
+                settings.CriteriaToSplit == ComponentSettings.SplitCriteria.PassiveSkillPoints);
+        }
+
+        private void AddCheckedSplits()
+        {
+            for (int i = 0; i < checkedSplitList.Items.Count; i++)
+            {
+                if (checkedSplitList.GetItemChecked(i))
+                {
+                    state.Run.AddSegment(checkedSplitList.Items[i].ToString());
+                }
+            }
+        }
+
+        private void AddCampaignSplits()
+        {
+            foreach (Zone zone in Zone.ZONES)
+            {
+                if (settings.SplitZones.Contains(zone))
+                {
+                    Image icon = null;
+                    if (settings.GenerateWithIcons)
+                    {
+                        icon = iconForType(Zone.ICONTYPES[zone]);
+                    }
+                    state.Run.AddSegment(zone.SplitName(), default(Time), default(Time), icon);
+                }
+            }
+            for (int i = 70; i <= 100; i++)
+            {
+                if (settings.SplitZoneLevels.Contains(i))
+                {
+                    state.Run.AddSegment(new LevelLabel(i).ToString());
+                }
+            }
+        }
+
+        private void AddPassiveSkillPointSplits()
+        {
+            foreach (PassiveSkillPointSplit split in PassiveSkillPointSplit.PRESETS)
+            {
+                if (settings.PassiveSkillPointSplits.Contains(split))
+                {
+                    state.Run.AddSegment(split.SplitName());
+                }
+            }
         }
 
         private Image iconForType(Zone.IconType type)
@@ -280,6 +323,11 @@ namespace POELiveSplitComponent.Component
         private void HandleIconsChecked(object sender, EventArgs e)
         {
             settings.GenerateWithIcons = checkIcons.Checked;
+        }
+
+        private void HandleCombineCampaignPassiveSkillPointsChecked(object sender, EventArgs e)
+        {
+            settings.CombineCampaignAndPassiveSkillPointSplits = checkCombineCampaignPassiveSkillPoints.Checked;
         }
     }
 }

--- a/POELiveSplitComponent/Component/Timer/LoadRemoverSplitter.cs
+++ b/POELiveSplitComponent/Component/Timer/LoadRemoverSplitter.cs
@@ -109,7 +109,7 @@ namespace POELiveSplitComponent.Component.Timer
             // See https://github.com/brandondong/POE-LiveSplit-Component/issues/8 for more details.
             IList<ISegment> segments = timer.CurrentState.Run;
             int currentIndex = timer.CurrentState.CurrentSplitIndex;
-            if (segments == null || currentIndex >= segments.Count)
+            if (segments == null || currentIndex < 0 || currentIndex >= segments.Count)
             {
                 return false;
             }
@@ -163,6 +163,33 @@ namespace POELiveSplitComponent.Component.Timer
                 timer.Start();
                 labStarted = true;
             }
+        }
+
+        public void HandleClientMessage(long timestamp, string message)
+        {
+            if (!settings.AutoSplitEnabled || settings.CriteriaToSplit != ComponentSettings.SplitCriteria.PassiveSkillPoints)
+            {
+                return;
+            }
+
+            PassiveSkillPointSplit split = PassiveSkillPointSplitForCurrentSegment();
+            if (split != null && split.Matches(message))
+            {
+                timer.Split();
+            }
+        }
+
+        private PassiveSkillPointSplit PassiveSkillPointSplitForCurrentSegment()
+        {
+            IList<ISegment> segments = timer.CurrentState.Run;
+            int currentIndex = timer.CurrentState.CurrentSplitIndex;
+            if (segments == null || currentIndex < 0 || currentIndex >= segments.Count)
+            {
+                return null;
+            }
+
+            ISegment currentSplit = segments[currentIndex];
+            return settings.PassiveSkillPointSplits.FirstOrDefault(split => split.SplitName() == currentSplit.Name);
         }
     }
 }

--- a/POELiveSplitComponent/Component/Timer/LoadRemoverSplitter.cs
+++ b/POELiveSplitComponent/Component/Timer/LoadRemoverSplitter.cs
@@ -72,7 +72,7 @@ namespace POELiveSplitComponent.Component.Timer
                         timer.Split();
                     }
                 }
-                else if (settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones)
+                else if (SplitsOnCampaignRoute())
                 {
                     if (ShouldSplitForCrtieraZone(zone))
                     {
@@ -83,6 +83,13 @@ namespace POELiveSplitComponent.Component.Timer
                 }
             }
             previousZone = zone;
+        }
+
+        private bool SplitsOnCampaignRoute()
+        {
+            return settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones ||
+                (settings.CriteriaToSplit == ComponentSettings.SplitCriteria.PassiveSkillPoints &&
+                settings.CombineCampaignAndPassiveSkillPointSplits);
         }
 
         public void HandleResetRuns()
@@ -138,7 +145,7 @@ namespace POELiveSplitComponent.Component.Timer
             {
                 return settings.SplitLevels;
             }
-            else if (settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones)
+            else if (SplitsOnCampaignRoute())
             {
                 return settings.SplitZoneLevels;
             }
@@ -167,7 +174,7 @@ namespace POELiveSplitComponent.Component.Timer
 
         public void HandleClientMessage(long timestamp, string message)
         {
-            if (!settings.AutoSplitEnabled || settings.CriteriaToSplit != ComponentSettings.SplitCriteria.PassiveSkillPoints)
+            if (!settings.AutoSplitEnabled || !SplitsOnPassiveSkillPoints())
             {
                 return;
             }
@@ -177,6 +184,13 @@ namespace POELiveSplitComponent.Component.Timer
             {
                 timer.Split();
             }
+        }
+
+        private bool SplitsOnPassiveSkillPoints()
+        {
+            return settings.CriteriaToSplit == ComponentSettings.SplitCriteria.PassiveSkillPoints ||
+                (settings.CriteriaToSplit == ComponentSettings.SplitCriteria.Zones &&
+                settings.CombineCampaignAndPassiveSkillPointSplits);
         }
 
         private PassiveSkillPointSplit PassiveSkillPointSplitForCurrentSegment()

--- a/POELiveSplitComponent/Component/Timer/PassiveSkillPointSplit.cs
+++ b/POELiveSplitComponent/Component/Timer/PassiveSkillPointSplit.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace POELiveSplitComponent.Component.Timer
+{
+    public class PassiveSkillPointSplit
+    {
+        public const string PASSIVE_SKILL_POINT_REGEX = @"^You have received (?:a|[0-9]+)\s+Passive Skill Points?\.$";
+
+        public static readonly List<PassiveSkillPointSplit> PRESETS = new List<PassiveSkillPointSplit>
+        {
+            new PassiveSkillPointSplit("Act 1 - The Dweller of the Deep"),
+            new PassiveSkillPointSplit("Act 1 - The Marooned Mariner"),
+            new PassiveSkillPointSplit("Act 1 - The Way Forward"),
+            new PassiveSkillPointSplit("Act 2 - Deal with the Bandits (Kill All)"),
+            new PassiveSkillPointSplit("Act 2 - Through Sacred Ground"),
+            new PassiveSkillPointSplit("Act 3 - Piety's Pets"),
+            new PassiveSkillPointSplit("Act 3 - Victario's Secrets"),
+            new PassiveSkillPointSplit("Act 4 - An Indomitable Spirit"),
+            new PassiveSkillPointSplit("Act 5 - In Service to Science"),
+            new PassiveSkillPointSplit("Act 5 - Kitava's Torments"),
+            new PassiveSkillPointSplit("Act 6 - The Cloven One"),
+            new PassiveSkillPointSplit("Act 6 - The Father of War"),
+            new PassiveSkillPointSplit("Act 6 - The Puppet Mistress"),
+            new PassiveSkillPointSplit("Act 7 - Kishara's Star"),
+            new PassiveSkillPointSplit("Act 7 - Queen of Despair"),
+            new PassiveSkillPointSplit("Act 7 - The Master of a Million Faces"),
+            new PassiveSkillPointSplit("Act 8 - Love is Dead"),
+            new PassiveSkillPointSplit("Act 8 - Reflection of Terror"),
+            new PassiveSkillPointSplit("Act 8 - The Gemling Legion"),
+            new PassiveSkillPointSplit("Act 9 - Queen of the Sands"),
+            new PassiveSkillPointSplit("Act 9 - The Ruler of Highgate"),
+            new PassiveSkillPointSplit("Act 10 - An End to Hunger"),
+            new PassiveSkillPointSplit("Act 10 - Vilenta's Vengeance"),
+        };
+
+        private readonly string name;
+
+        private PassiveSkillPointSplit(string name)
+        {
+            this.name = name;
+        }
+
+        public string Serialize()
+        {
+            return name;
+        }
+
+        public string SplitName()
+        {
+            return name;
+        }
+
+        public bool Matches(string message)
+        {
+            return Regex.IsMatch(message, PASSIVE_SKILL_POINT_REGEX, RegexOptions.IgnoreCase);
+        }
+
+        public override string ToString()
+        {
+            return SplitName();
+        }
+
+        public override bool Equals(object obj)
+        {
+            PassiveSkillPointSplit split = obj as PassiveSkillPointSplit;
+            if (split == null)
+            {
+                return false;
+            }
+            return name.Equals(split.name);
+        }
+
+        public override int GetHashCode()
+        {
+            return name.GetHashCode();
+        }
+    }
+}

--- a/POELiveSplitComponent/POELiveSplitComponent.csproj
+++ b/POELiveSplitComponent/POELiveSplitComponent.csproj
@@ -62,6 +62,7 @@
       <DependentUpon>SettingsControl.cs</DependentUpon>
     </Compile>
     <Compile Include="Component\Timer\LoadRemoverSplitter.cs" />
+    <Compile Include="Component\Timer\PassiveSkillPointSplit.cs" />
     <Compile Include="Component\Timer\Zone.cs" />
     <Compile Include="Component\UI\LevelLabel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/POELiveSplitComponentTests/Component/GameClient/ClientParserTests.cs
+++ b/POELiveSplitComponentTests/Component/GameClient/ClientParserTests.cs
@@ -43,6 +43,11 @@ namespace POELiveSplitComponentTests.Component.GameClient
             {
                 throw new NotImplementedException();
             }
+
+            public virtual void HandleClientMessage(long timestamp, string message)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         class ExpectedLoadStart : MockClientEventHandler
@@ -108,6 +113,23 @@ namespace POELiveSplitComponentTests.Component.GameClient
             }
         }
 
+        class ExpectedClientMessage : MockClientEventHandler
+        {
+            private string expectedMessage;
+
+            public ExpectedClientMessage(long expectedTimestamp, string expectedMessage) : base(expectedTimestamp)
+            {
+                this.expectedMessage = expectedMessage;
+            }
+
+            public override void HandleClientMessage(long timestamp, string message)
+            {
+                Assert.AreEqual(expectedTimestamp, timestamp);
+                Assert.AreEqual(expectedMessage, message);
+                handledEvent = true;
+            }
+        }
+
         [TestMethod()]
         public void ProcessEnterZoneStart()
         {
@@ -141,6 +163,15 @@ namespace POELiveSplitComponentTests.Component.GameClient
             ExpectedIzaroDialogue expected = new ExpectedIzaroDialogue(911705671, "Delight in your gilded dungeon, ascendant.");
             ClientParser parser = new ClientParser(expected);
             parser.ProcessLine("2020/02/05 23:51:54 911705671 ac9 [INFO Client 10980] Izaro: Delight in your gilded dungeon, ascendant.");
+            expected.AssertEventProcessed();
+        }
+
+        [TestMethod()]
+        public void ProcessClientMessage()
+        {
+            ExpectedClientMessage expected = new ExpectedClientMessage(452201156, "You have received a Passive Skill Point.");
+            ClientParser parser = new ClientParser(expected);
+            parser.ProcessLine("2026/06/06 17:42:15 452201156 cffb06dd [INFO Client 18012] : You have received a Passive Skill Point.");
             expected.AssertEventProcessed();
         }
     }

--- a/POELiveSplitComponentTests/Component/Settings/ComponentSettingsTests.cs
+++ b/POELiveSplitComponentTests/Component/Settings/ComponentSettingsTests.cs
@@ -25,6 +25,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.AreEqual(0, settings.SplitZones.Count);
             Assert.AreEqual(0, settings.SplitZoneLevels.Count);
             Assert.AreEqual(0, settings.SplitLevels.Count);
+            Assert.AreEqual(0, settings.PassiveSkillPointSplits.Count);
         }
 
         [TestMethod()]
@@ -53,6 +54,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.AreEqual(2, settings.SplitZones.Count);
             Assert.AreEqual(0, settings.SplitZoneLevels.Count);
             Assert.AreEqual(0, settings.SplitLevels.Count);
+            Assert.AreEqual(0, settings.PassiveSkillPointSplits.Count);
             Assert.AreEqual("C:/Program Files (x86)/Grinding Gear Games/Path of Exile/logs/client.txt", settings.LogLocation);
         }
 
@@ -87,6 +89,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.AreEqual(3, settings.SplitZones.Count);
             Assert.IsTrue(new HashSet<int> { 70 }.SetEquals(settings.SplitZoneLevels));
             Assert.IsTrue(new HashSet<int> { 3 }.SetEquals(settings.SplitLevels));
+            Assert.AreEqual(0, settings.PassiveSkillPointSplits.Count);
             Assert.AreEqual(@"C:\Program Files (x86)\Grinding Gear Games\Path of Exile\logs\Client.txt", settings.LogLocation);
         }
 
@@ -120,6 +123,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.AreEqual(3, settings.SplitZones.Count);
             Assert.AreEqual(0, settings.SplitZoneLevels.Count);
             Assert.AreEqual(1, settings.SplitLevels.Count);
+            Assert.AreEqual(0, settings.PassiveSkillPointSplits.Count);
             Assert.AreEqual(@"C:\Program Files (x86)\Grinding Gear Games\Path of Exile\logs\Client.txt", settings.LogLocation);
         }
 
@@ -140,6 +144,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.AreEqual(0, settings.SplitZones.Count);
             Assert.AreEqual(0, settings.SplitZoneLevels.Count);
             Assert.AreEqual(0, settings.SplitLevels.Count);
+            Assert.AreEqual(0, settings.PassiveSkillPointSplits.Count);
         }
 
         [TestMethod()]
@@ -155,6 +160,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             settings.SplitZones.Add(Zone.ZONES[0]);
             settings.SplitZoneLevels.Add(70);
             settings.SplitLevels.Add(100);
+            settings.PassiveSkillPointSplits.Add(PassiveSkillPointSplit.PRESETS[0]);
             XmlNode node = settings.GetSettings(xml);
 
             settings = new ComponentSettings();
@@ -167,6 +173,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.IsTrue(new HashSet<IZone> { Zone.ZONES[0] }.SetEquals(settings.SplitZones));
             Assert.IsTrue(new HashSet<int> { 70 }.SetEquals(settings.SplitZoneLevels));
             Assert.IsTrue(new HashSet<int> { 100 }.SetEquals(settings.SplitLevels));
+            Assert.IsTrue(new HashSet<PassiveSkillPointSplit> { PassiveSkillPointSplit.PRESETS[0] }.SetEquals(settings.PassiveSkillPointSplits));
         }
 
         [TestMethod()]
@@ -181,6 +188,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             settings.SplitZones.Add(Zone.ZONES[0]);
             settings.SplitZoneLevels.Add(70);
             settings.SplitLevels.Add(100);
+            settings.PassiveSkillPointSplits.Add(PassiveSkillPointSplit.PRESETS[0]);
             
             // Emulate a cancel.
             XmlDocument xml = new XmlDocument();
@@ -193,6 +201,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.AreEqual(0, settings.SplitZones.Count);
             Assert.AreEqual(0, settings.SplitZoneLevels.Count);
             Assert.AreEqual(0, settings.SplitLevels.Count);
+            Assert.AreEqual(0, settings.PassiveSkillPointSplits.Count);
         }
 
         [TestMethod()]
@@ -207,6 +216,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             settings.SplitZones.Add(Zone.ZONES[0]);
             settings.SplitZoneLevels.Add(70);
             settings.SplitLevels.Add(100);
+            settings.PassiveSkillPointSplits.Add(PassiveSkillPointSplit.PRESETS[0]);
 
             // Emulate a cancel where the properties were fetched from file.
             // Never has been observed but we'll handle it anyways.
@@ -222,6 +232,30 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.AreEqual(0, settings.SplitZones.Count);
             Assert.AreEqual(0, settings.SplitZoneLevels.Count);
             Assert.AreEqual(0, settings.SplitLevels.Count);
+            Assert.AreEqual(0, settings.PassiveSkillPointSplits.Count);
+        }
+
+        [TestMethod()]
+        public void SetSettingsWithPassiveSkillPointSplitsTest()
+        {
+            XmlDocument xml = new XmlDocument();
+            xml.LoadXml(
+@"<AutoSplitterSettings>
+   <split.criteria>PassiveSkillPoints</split.criteria>
+   <split.passive.skill.points.on>
+      <split.passive.skill.point>Act 1 - The Dweller of the Deep</split.passive.skill.point>
+      <split.passive.skill.point>Act 2 - Deal with the Bandits (Kill All)</split.passive.skill.point>
+   </split.passive.skill.points.on>
+</AutoSplitterSettings>");
+            XmlNode nodeSettings = xml.FirstChild;
+            ComponentSettings settings = new ComponentSettings();
+            settings.SetSettings(nodeSettings);
+            Assert.AreEqual(ComponentSettings.SplitCriteria.PassiveSkillPoints, settings.CriteriaToSplit);
+            Assert.IsTrue(new HashSet<PassiveSkillPointSplit>
+            {
+                PassiveSkillPointSplit.PRESETS[0],
+                PassiveSkillPointSplit.PRESETS[3]
+            }.SetEquals(settings.PassiveSkillPointSplits));
         }
     }
 }

--- a/POELiveSplitComponentTests/Component/Settings/ComponentSettingsTests.cs
+++ b/POELiveSplitComponentTests/Component/Settings/ComponentSettingsTests.cs
@@ -21,6 +21,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.IsFalse(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.AllZones, settings.LabSplitType);
             Assert.IsTrue(settings.GenerateWithIcons);
+            Assert.IsFalse(settings.CombineCampaignAndPassiveSkillPointSplits);
             Assert.AreEqual(ComponentSettings.SplitCriteria.Zones, settings.CriteriaToSplit);
             Assert.AreEqual(0, settings.SplitZones.Count);
             Assert.AreEqual(0, settings.SplitZoneLevels.Count);
@@ -50,6 +51,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.IsTrue(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.AllZones, settings.LabSplitType);
             Assert.IsTrue(settings.GenerateWithIcons);
+            Assert.IsFalse(settings.CombineCampaignAndPassiveSkillPointSplits);
             Assert.AreEqual(ComponentSettings.SplitCriteria.Zones, settings.CriteriaToSplit);
             Assert.AreEqual(2, settings.SplitZones.Count);
             Assert.AreEqual(0, settings.SplitZoneLevels.Count);
@@ -140,6 +142,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.IsFalse(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.AllZones, settings.LabSplitType);
             Assert.IsTrue(settings.GenerateWithIcons);
+            Assert.IsFalse(settings.CombineCampaignAndPassiveSkillPointSplits);
             Assert.AreEqual(ComponentSettings.SplitCriteria.Zones, settings.CriteriaToSplit);
             Assert.AreEqual(0, settings.SplitZones.Count);
             Assert.AreEqual(0, settings.SplitZoneLevels.Count);
@@ -156,6 +159,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             settings.LoadRemovalEnabled = true;
             settings.LabSplitType = ComponentSettings.LabSplitMode.Trials;
             settings.GenerateWithIcons = false;
+            settings.CombineCampaignAndPassiveSkillPointSplits = true;
             settings.CriteriaToSplit = ComponentSettings.SplitCriteria.Levels;
             settings.SplitZones.Add(Zone.ZONES[0]);
             settings.SplitZoneLevels.Add(70);
@@ -169,6 +173,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.IsTrue(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.Trials, settings.LabSplitType);
             Assert.IsFalse(settings.GenerateWithIcons);
+            Assert.IsTrue(settings.CombineCampaignAndPassiveSkillPointSplits);
             Assert.AreEqual(ComponentSettings.SplitCriteria.Levels, settings.CriteriaToSplit);
             Assert.IsTrue(new HashSet<IZone> { Zone.ZONES[0] }.SetEquals(settings.SplitZones));
             Assert.IsTrue(new HashSet<int> { 70 }.SetEquals(settings.SplitZoneLevels));
@@ -184,6 +189,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             settings.LoadRemovalEnabled = true;
             settings.LabSplitType = ComponentSettings.LabSplitMode.Trials;
             settings.GenerateWithIcons = false;
+            settings.CombineCampaignAndPassiveSkillPointSplits = true;
             settings.CriteriaToSplit = ComponentSettings.SplitCriteria.Levels;
             settings.SplitZones.Add(Zone.ZONES[0]);
             settings.SplitZoneLevels.Add(70);
@@ -197,6 +203,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.IsFalse(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.AllZones, settings.LabSplitType);
             Assert.IsTrue(settings.GenerateWithIcons);
+            Assert.IsFalse(settings.CombineCampaignAndPassiveSkillPointSplits);
             Assert.AreEqual(ComponentSettings.SplitCriteria.Zones, settings.CriteriaToSplit);
             Assert.AreEqual(0, settings.SplitZones.Count);
             Assert.AreEqual(0, settings.SplitZoneLevels.Count);
@@ -212,6 +219,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             settings.LoadRemovalEnabled = true;
             settings.LabSplitType = ComponentSettings.LabSplitMode.Trials;
             settings.GenerateWithIcons = false;
+            settings.CombineCampaignAndPassiveSkillPointSplits = true;
             settings.CriteriaToSplit = ComponentSettings.SplitCriteria.Labyrinth;
             settings.SplitZones.Add(Zone.ZONES[0]);
             settings.SplitZoneLevels.Add(70);
@@ -228,6 +236,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             Assert.IsTrue(settings.LoadRemovalEnabled);
             Assert.AreEqual(ComponentSettings.LabSplitMode.AllZones, settings.LabSplitType);
             Assert.IsTrue(settings.GenerateWithIcons);
+            Assert.IsFalse(settings.CombineCampaignAndPassiveSkillPointSplits);
             Assert.AreEqual(ComponentSettings.SplitCriteria.Zones, settings.CriteriaToSplit);
             Assert.AreEqual(0, settings.SplitZones.Count);
             Assert.AreEqual(0, settings.SplitZoneLevels.Count);
@@ -242,6 +251,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             xml.LoadXml(
 @"<AutoSplitterSettings>
    <split.criteria>PassiveSkillPoints</split.criteria>
+   <combine.campaign.and.passive.skill.point.splits>True</combine.campaign.and.passive.skill.point.splits>
    <split.passive.skill.points.on>
       <split.passive.skill.point>Act 1 - The Dweller of the Deep</split.passive.skill.point>
       <split.passive.skill.point>Act 2 - Deal with the Bandits (Kill All)</split.passive.skill.point>
@@ -251,6 +261,7 @@ namespace POELiveSplitComponentTests.Component.Settings
             ComponentSettings settings = new ComponentSettings();
             settings.SetSettings(nodeSettings);
             Assert.AreEqual(ComponentSettings.SplitCriteria.PassiveSkillPoints, settings.CriteriaToSplit);
+            Assert.IsTrue(settings.CombineCampaignAndPassiveSkillPointSplits);
             Assert.IsTrue(new HashSet<PassiveSkillPointSplit>
             {
                 PassiveSkillPointSplit.PRESETS[0],

--- a/POELiveSplitComponentTests/Component/Timer/LoadRemoverSplitterTests.cs
+++ b/POELiveSplitComponentTests/Component/Timer/LoadRemoverSplitterTests.cs
@@ -1,4 +1,5 @@
 using LiveSplit.Model;
+using LiveSplit.Model.Comparisons;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using LiveSplit.Model.Input;
@@ -15,6 +16,7 @@ namespace POELiveSplitComponentTests.Component.Timer
         {
             public int NumSplits = 0;
             public int NumStarts = 0;
+            private LiveSplitState currentState = (LiveSplitState)FormatterServices.GetUninitializedObject(typeof(LiveSplitState));
 
             public void Split()
             {
@@ -30,12 +32,12 @@ namespace POELiveSplitComponentTests.Component.Timer
             {
                 get
                 {
-                    return (LiveSplitState)FormatterServices.GetUninitializedObject(typeof(LiveSplitState));
+                    return currentState;
                 }
 
                 set
                 {
-                    throw new NotImplementedException();
+                    currentState = value;
                 }
             }
 
@@ -230,8 +232,31 @@ namespace POELiveSplitComponentTests.Component.Timer
                 splitter.HandleLevelUp(2, 70);
                 splitter.HandleLoadStart(3);
                 splitter.HandleLoadEnd(4, "Lioneye's Watch");
+                splitter.HandleClientMessage(5, "You have received a Passive Skill Point.");
                 Assert.AreEqual(0, timer.NumSplits);
             }
+        }
+
+        [TestMethod()]
+        public void HandlePassiveSkillPointMessageTest()
+        {
+            PassiveSkillPointSplit passiveSplit = PassiveSkillPointSplit.PRESETS[0];
+            ComponentSettings settings = new ComponentSettings();
+            settings.CriteriaToSplit = ComponentSettings.SplitCriteria.PassiveSkillPoints;
+            settings.PassiveSkillPointSplits.Add(passiveSplit);
+            MockTimerModel timer = new MockTimerModel();
+            Run run = new Run(new StandardComparisonGeneratorsFactory());
+            Segment segment = (Segment)FormatterServices.GetUninitializedObject(typeof(Segment));
+            segment.Name = passiveSplit.SplitName();
+            run.Add(segment);
+            timer.CurrentState.Run = run;
+            timer.CurrentState.CurrentSplitIndex = 0;
+
+            LoadRemoverSplitter splitter = new LoadRemoverSplitter(timer, settings);
+            splitter.HandleClientMessage(1, "You have received a Passive Skill Point.");
+            Assert.AreEqual(1, timer.NumSplits);
+            splitter.HandleClientMessage(2, "Player: You have received a Passive Skill Point.");
+            Assert.AreEqual(1, timer.NumSplits);
         }
 
         [TestMethod()]

--- a/POELiveSplitComponentTests/Component/Timer/LoadRemoverSplitterTests.cs
+++ b/POELiveSplitComponentTests/Component/Timer/LoadRemoverSplitterTests.cs
@@ -214,6 +214,43 @@ namespace POELiveSplitComponentTests.Component.Timer
         }
 
         [TestMethod()]
+        public void HandlePassiveSkillPointsModeSplitsCampaignRouteTest()
+        {
+            ComponentSettings settings = new ComponentSettings();
+            settings.CriteriaToSplit = ComponentSettings.SplitCriteria.PassiveSkillPoints;
+            settings.CombineCampaignAndPassiveSkillPointSplits = true;
+            settings.SplitZones.Add(LIONEYES1);
+            settings.SplitZoneLevels.Add(70);
+            settings.SplitLevels.Add(2);
+            MockTimerModel timer = new MockTimerModel();
+
+            LoadRemoverSplitter splitter = new LoadRemoverSplitter(timer, settings);
+            splitter.HandleLoadStart(1);
+            splitter.HandleLoadEnd(2, "Lioneye's Watch");
+            Assert.AreEqual(1, timer.NumSplits);
+            splitter.HandleLevelUp(3, 2);
+            Assert.AreEqual(1, timer.NumSplits);
+            splitter.HandleLevelUp(4, 70);
+            Assert.AreEqual(2, timer.NumSplits);
+        }
+
+        [TestMethod()]
+        public void HandlePassiveSkillPointsModeDoesNotSplitCampaignRouteByDefaultTest()
+        {
+            ComponentSettings settings = new ComponentSettings();
+            settings.CriteriaToSplit = ComponentSettings.SplitCriteria.PassiveSkillPoints;
+            settings.SplitZones.Add(LIONEYES1);
+            settings.SplitZoneLevels.Add(70);
+            MockTimerModel timer = new MockTimerModel();
+
+            LoadRemoverSplitter splitter = new LoadRemoverSplitter(timer, settings);
+            splitter.HandleLoadStart(1);
+            splitter.HandleLoadEnd(2, "Lioneye's Watch");
+            splitter.HandleLevelUp(3, 70);
+            Assert.AreEqual(0, timer.NumSplits);
+        }
+
+        [TestMethod()]
         public void HandleAutosplitDisabledTest()
         {
             foreach (ComponentSettings.SplitCriteria c in Enum.GetValues(typeof(ComponentSettings.SplitCriteria)))
@@ -240,9 +277,37 @@ namespace POELiveSplitComponentTests.Component.Timer
         [TestMethod()]
         public void HandlePassiveSkillPointMessageTest()
         {
+            HandlePassiveSkillPointMessageTestForCriteria(ComponentSettings.SplitCriteria.PassiveSkillPoints);
+        }
+
+        [TestMethod()]
+        public void HandlePassiveSkillPointMessageInZonesModeTest()
+        {
+            HandlePassiveSkillPointMessageTestForCriteria(ComponentSettings.SplitCriteria.Zones, true);
+        }
+
+        [TestMethod()]
+        public void HandlePassiveSkillPointMessageInZonesModeRequiresCombineSettingTest()
+        {
+            HandlePassiveSkillPointMessageTestForCriteria(ComponentSettings.SplitCriteria.Zones, false, 0);
+        }
+
+        private void HandlePassiveSkillPointMessageTestForCriteria(ComponentSettings.SplitCriteria criteria)
+        {
+            HandlePassiveSkillPointMessageTestForCriteria(criteria, false);
+        }
+
+        private void HandlePassiveSkillPointMessageTestForCriteria(ComponentSettings.SplitCriteria criteria, bool combine)
+        {
+            HandlePassiveSkillPointMessageTestForCriteria(criteria, combine, 1);
+        }
+
+        private void HandlePassiveSkillPointMessageTestForCriteria(ComponentSettings.SplitCriteria criteria, bool combine, int expectedSplits)
+        {
             PassiveSkillPointSplit passiveSplit = PassiveSkillPointSplit.PRESETS[0];
             ComponentSettings settings = new ComponentSettings();
-            settings.CriteriaToSplit = ComponentSettings.SplitCriteria.PassiveSkillPoints;
+            settings.CriteriaToSplit = criteria;
+            settings.CombineCampaignAndPassiveSkillPointSplits = combine;
             settings.PassiveSkillPointSplits.Add(passiveSplit);
             MockTimerModel timer = new MockTimerModel();
             Run run = new Run(new StandardComparisonGeneratorsFactory());
@@ -254,9 +319,9 @@ namespace POELiveSplitComponentTests.Component.Timer
 
             LoadRemoverSplitter splitter = new LoadRemoverSplitter(timer, settings);
             splitter.HandleClientMessage(1, "You have received a Passive Skill Point.");
-            Assert.AreEqual(1, timer.NumSplits);
+            Assert.AreEqual(expectedSplits, timer.NumSplits);
             splitter.HandleClientMessage(2, "Player: You have received a Passive Skill Point.");
-            Assert.AreEqual(1, timer.NumSplits);
+            Assert.AreEqual(expectedSplits, timer.NumSplits);
         }
 
         [TestMethod()]

--- a/POELiveSplitComponentTests/Component/Timer/ZoneTests.cs
+++ b/POELiveSplitComponentTests/Component/Timer/ZoneTests.cs
@@ -80,5 +80,14 @@ namespace POELiveSplitComponentTests.Component.Timer
             Assert.AreEqual(Zone.IconType.Wp, Zone.ICONTYPES[Zone.Parse("The Coast", new HashSet<IZone>())]);
             Assert.AreEqual(Zone.IconType.NoWp, Zone.ICONTYPES[Zone.Parse("The Tidal Island", new HashSet<IZone>())]);
         }
+
+        [TestMethod()]
+        public void PassiveSkillPointSplitMatchesTest()
+        {
+            PassiveSkillPointSplit split = PassiveSkillPointSplit.PRESETS[0];
+            Assert.IsTrue(split.Matches("You have received a Passive Skill Point."));
+            Assert.IsTrue(split.Matches("You have received 2 Passive Skill Points."));
+            Assert.IsFalse(split.Matches("You have received 2 Passive Respec Points."));
+        }
     }
 }


### PR DESCRIPTION
## Summary
Added a Passive Skill Points split mode, which can optionally be combined with Campaign split mode.

<img width="1178" height="482" alt="image" src="https://github.com/user-attachments/assets/96dbb61c-8260-4cf6-a625-ac49c4acc840" />

This feature allows runners to create a more detailed splits for Book of Skill segments. It also aids in the process of remembering Book of Skill quests during league starts.

The split checks for an INFO client message matching this regex:
```regex
^You have received (?:a|[0-9]+)\s+Passive Skill Points?\.$
```
If the current segment is a Passive Skill Point segment and the regex matches, the component autosplits.

All 23 additional passive point quests are accounted for.

I’m unsure whether this should be enabled by default, so I added an option to combine Campaign + Passive Skill Points split modes. Happy to remove that option and make it default to combined with Campaign if preferred.

## Notes
This PR has merge conflicts with https://github.com/brandondong/POE-LiveSplit-Component/pull/23
- POELiveSplitComponent/Component/SettingsControl.Designer.cs
- POELiveSplitComponent/Component/Timer/LoadRemoverSplitter.cs
- POELiveSplitComponentTests/Component/Timer/LoadRemoverSplitterTests.cs

Happy to help with merging if either one gets merged into master.

## Testing
- [x] Test cases pass
- [x] Manually verified that it splits when a Book of Skill is consumed during the segment

<img width="282" height="522" alt="image" src="https://github.com/user-attachments/assets/42e27ee8-28ad-4596-806d-7dc28d98938c" />